### PR TITLE
Improved duplicate solution

### DIFF
--- a/registration/forms/duplicates.py
+++ b/registration/forms/duplicates.py
@@ -1,35 +1,104 @@
 from django import forms
 
+from pprint import pprint
 
 class MergeDuplicatesForm(forms.Form):
     def __init__(self, *args, **kwargs):
-        self._helpers = kwargs.pop('helpers')
+        self.helpers = kwargs.pop('helpers')
 
         super(MergeDuplicatesForm, self).__init__(*args, **kwargs)
+        self.fields['helper_comment'] = forms.ModelChoiceField(
+            queryset=self.helpers,
+            required=False,
+            widget=forms.RadioSelect()
+        )
+        self.fields['helper_email'] = forms.ModelChoiceField(
+            queryset=self.helpers,
+            widget=forms.RadioSelect()
+        )
+        self.fields['helper_name'] = forms.ModelChoiceField(
+            queryset=self.helpers,
+            widget=forms.RadioSelect()
+        )
+        self.fields['helper_phone'] = forms.ModelChoiceField(
+            queryset=self.helpers,
+            widget=forms.RadioSelect()
+        )
+        self.fields['helper_shirt'] = forms.ModelChoiceField(
+            queryset=self.helpers,
+            required=False,
+            widget=forms.RadioSelect()
+        )
+        self.fields['helper_infection_instruction'] = forms.ModelChoiceField(
+            queryset=self.helpers,
+            required=False,
+            widget=forms.RadioSelect()
+        )
+        self.fields['helper_vegetarian'] = forms.ModelChoiceField(
+            queryset=self.helpers,
+            required=False,
+            widget=forms.RadioSelect()
+        )
+        self.fields['helper_barcode'] = forms.ModelChoiceField(
+            queryset=self.helpers,
+            required=False,
+            widget=forms.RadioSelect()
+        )
+        self.fields['helper_shifts'] = forms.ModelMultipleChoiceField(
+            queryset=self.helpers,
+            widget=forms.CheckboxSelectMultiple(attrs={'id': 'helper'}),
+            label='helpers_shifts')
 
-        self.fields['helpers'] = forms.ModelChoiceField(
-            queryset=self._helpers,
-            widget=forms.RadioSelect(attrs={'id': 'helper'}),
-            empty_label=None,
-            required=True,
-            label='')
+        self.fields['helper_delete'] = forms.ModelMultipleChoiceField(
+            queryset=self.helpers,
+            widget=forms.CheckboxSelectMultiple(attrs={'id': 'helper'}),
+            label='helpers_shifts')
+
 
     def merge(self):
-        remaining_helper = self.cleaned_data['helpers']
+        pprint(self.cleaned_data)
+        ref = self.cleaned_data['helper_email']
 
-        for helper in self._helpers:
-            if helper != remaining_helper:
+        if self.cleaned_data['helper_comment']:
+            ref.comment = self.cleaned_data['helper_comment'].comment
+
+        # Merging email is not necessary - email is our reference!
+
+        if self.cleaned_data['helper_name']:
+            ref.firstname = self.cleaned_data['helper_name'].firstname
+            ref.surname = self.cleaned_data['helper_name'].surname
+
+        if self.cleaned_data['helper_phone']:
+            ref.phone = self.cleaned_data['helper_phone'].phone
+
+        if self.cleaned_data['helper_shirt']:
+            ref.shirt = self.cleaned_data['helper_shirt'].shirt
+
+        if self.cleaned_data['helper_infection_instruction']:
+            ref.infection_instruction = self.cleaned_data['helper_infection_instruction'].infection_instruction
+
+        if self.cleaned_data['helper_vegetarian']:
+            ref.vegetarian = self.cleaned_data['helper_vegetarian'].vegetarian
+
+        # Now merge all shifts that are marked for merging
+        for helper in self.cleaned_data['helper_shifts']:
+            if helper != ref:
                 # merge shifts
                 for shift in helper.shifts.all():
-                    remaining_helper.shifts.add(shift)
+                    ref.shifts.add(shift)
 
                 # merged coordinated jobs
                 for job in helper.coordinated_jobs:
-                    job.coordinators.add(remaining_helper)
+                    job.coordinators.add(ref)
 
-                if remaining_helper.event.gifts:
-                    remaining_helper.gifts.merge(helper.gifts)
+                if ref.event.gifts:
+                    ref.gifts.merge(helper.gifts)
 
+        # TODO Do duplicate checking here!
+
+        # Delete all duplicates that are marked for deleting - except ref!
+        for helper in self.cleaned_data['helper_delete']:
+            if helper != ref:
                 helper.delete()
 
-        return remaining_helper
+        return ref

--- a/registration/templates/registration/admin/merge.html
+++ b/registration/templates/registration/admin/merge.html
@@ -22,20 +22,154 @@
 
             {% bootstrap_form_errors form %}
 
-            {% for helper in form.helpers.field.queryset %}
-                <input id="helper_{{ forloop.counter0 }}"
-                       name="helpers"
-                       required="required"
-                       type="radio"
+            {% for helper in form.helpers %}
+            <table clas="table-condensed">
+                <tr>
+                    <th>{% trans "Name" %}: </th>
+                    <td>
+                        <input id="helper_name_{{ forloop.counter0}}"
+                               name="helper_name"
+                               type="radio"
+                               required="required"
+                               value="{{ helper.pk }}"
+                        />
+                        <label for="helper_name_{{ forloop.counter0}}">
+                            {{ helper.firstname }} {{ helper.surname }}
+                        </label>
+                        </td>
+                </tr>
+
+                <tr>
+                    <th>{% trans "E-Mail" %}: </th>
+                    <td>
+                        <input id="helper_email_{{ forloop.counter0}}"
+                               name="helper_email"
+                               type="radio"
+                               required="required"
+                               value="{{ helper.pk }}"
+                        />
+                        <label for="helper_email_{{ forloop.counter0}}">
+                            {{ helper.email }}
+                        </label>
+                    </td>
+                </tr>
+
+                <tr>
+                    <th>{% trans "Mobile phone" %}: </th>
+                    <td>
+                        <input id="helper_phone_{{ forloop.counter0}}"
+                               name="helper_phone"
+                               type="radio"
+                               required="required"
+                               value="{{ helper.pk }}"
+                        />
+                        <label for="helper_phone_{{ forloop.counter0}}">
+                            {{ helper.phone }}
+                        </label>
+                    </td>
+                </tr>
+
+                {% if event.ask_shirt %}
+                <tr>
+                    <th>{% trans "T-shirt" %}: </th>
+                    <td>
+                        <input id="helper_shirt_{{ forloop.counter0}}"
+                               name="helper_shirt"
+                               type="radio"
+                               value="{{ helper.pk }}"
+                        />
+                        <label for="helper_shirt_{{ forloop.counter0}}">
+                            {{ helper.get_shirt_display }}
+                        </label>
+                    </td>
+                </tr>
+                {% endif %}
+
+                {% if helper.needs_infection_instruction %}
+                <tr>
+                    <th>{% trans "Instruction for the handling of food" %}: </th>
+                    <td>
+                        <input id="helper_infection_instruction_{{ forloop.counter0}}"
+                               name="helper_infection_instruction"
+                               type="radio"
+                               value="{{ helper.pk }}"
+                        />
+                        <label for="helper_infection_instruction_{{ forloop.counter0}}">
+                            {{ helper.get_infection_instruction_display }}
+                        </label>
+                    </td>
+                </tr>
+                {% endif %}
+
+                {% if event.ask_vegetarian %}
+                <tr>
+                    <th>{% trans "Vegetarian" %}: </th>
+                    <td>
+                        <input id="helper_vegetarian_{{ forloop.counter0}}"
+                               name="helper_vegetarian"
+                               type="radio"
+                               value="{{ helper.pk }}"
+                        />
+                        <label for="helper_vegetarian_{{ forloop.counter0}}">
+                            {{ helper.vegetarian | yesno }}
+                        </label>
+                    </td>
+                </tr>
+                {% endif %}
+
+                <tr>
+                    <th>{% trans "Comment" %}: </th>
+                    <td>
+                        <input id="helper_comment_{{ forloop.counter0}}"
+                               name="helper_comment"
+                               type="radio"
+                               value="{{ helper.pk }}"
+                        />
+                        <label for="helper_comment_{{ forloop.counter0}}">
+                            {{ helper.comment | default:"-" }}
+                        </label>
+                    </td>
+                </tr>
+
+                {% if badge_barcode %}
+                <tr>
+                    <th>{% trans "Badge Barcode" %}</th>
+                    <td>
+                        <input id="helper_barcode_{{ forloop.counter0}}"
+                               name="helper_barcode"
+                               type="radio"
+                               value="{{ helper.pk }}"
+                        />
+                        <label for="helper_barcode_{{ forloop.counter0}}">
+                        {{ badge_barcode }}
+                        </label>
+                    </td>
+                </tr>
+                {% endif %}
+            </table>
+           <input id="helper_shifts_{{ forloop.counter0 }}"
+                   name="helper_shifts"
+                   type="checkbox"
+                   value="{{ helper.pk }}"
+            />
+            <label for="helper_shifts_{{ forloop.counter0 }}">
+                {% trans "Merge these shifts" %}
+            </label>
+            <ul>
+                {% for shift in helper.shifts.all|dictsort:"begin" %}
+                <li>{{ shift }}</li>
+                {% endfor %}
+            </ul
+            <p>
+                <input id="helper_delete_{{ forloop.counter0 }}"
+                       name="helper_delete"
+                       type="checkbox"
                        value="{{ helper.pk }}"
-                />
-                <label for="helper_{{ forloop.counter0 }}">
-                    {% trans "Keep this data" %}
+                /><label for="helper_delete_{{ forloop.counter0 }}">
+                    {% trans "This is one of the duplicates. Do not keep him" %}
                 </label>
-
-                {% include "registration/helper_data.html" with helper=helper %}
-
-                <div style="margin-bottom: 2em;"></div>
+            </p>
+            <div style="margin-bottom: 2em;"></div>
             {% endfor %}
 
             <input type="submit" value="{% trans "Merge" %}" class="btn btn-default" />


### PR DESCRIPTION
I have improved the Duplicate resolution, since we were encountering cases, where multiple people used one email-adress to register with different names in different shifts. 

This new Interface is not beautiful, maybe some helper buttons like "select all" would be helpful. 

You can now select the Value you want to use for every field of the helper. Also you can decide, which you want to merge together and remove them afterwards. 

To achieve the same result as before, you select all values from one of the entries and select all "merge" and "this is one of the duplicates, please delete" options. 

Afterwards everything is getting merged into the helper, that is referred to by the selected email-adress. 