### PR TITLE
Helper was displayed multiple times for shift X if he does multiple shifts

### DIFF
--- a/src/prerequisites/views/helper.py
+++ b/src/prerequisites/views/helper.py
@@ -30,7 +30,7 @@ def view_helpers_prerequisite(request, event_url_name, prerequisite_pk):
         raise Http404
 
     # find all helpers that need this prerequisite
-    helpers = Helper.objects.filter(shifts__job__prerequisites=prerequisite)
+    helpers = Helper.objects.filter(shifts__job__prerequisites=prerequisite).distinct()
 
     # render page
     context = {'event': event,


### PR DESCRIPTION
a helper with more than one shift was listed more than once in the
"helper that require prerequisite X".