### PR TITLE
Hide events older than a couple of years

### DIFF
--- a/src/helfertool.yaml
+++ b/src/helfertool.yaml
@@ -1,4 +1,4 @@
-# Show this announcement on every page (for example for maintenance) 
+# Show this announcement on every page (for example for maintenance)
 #announcement: ""
 
 # Location of uploaded files, static files and temporary files.
@@ -226,6 +226,11 @@ security:
 
 # Custom URLs, mail addresses, ...
 customization:
+    # Modify certain properties for the general helfertool to display
+    display:
+        # Maximum age for events to be displayed by default on the index page
+        event_max_age_years: 1
+
     # There are some external links that should/can be changed
     urls:
         # Imprint with contact details

--- a/src/helfertool/settings.py
+++ b/src/helfertool/settings.py
@@ -389,6 +389,11 @@ if is_docker:
 
     LOGGING['loggers']['helfertool']['handlers'].append('helfertool_syslog_docker')
 
+# Display Options
+# Maximum age of events displayed on index
+DISPLAY_EVENT_MAX_AGE_YEARS = int(dict_get(config, 3, 'customization',
+                                  'display', 'event_max_age_years'))
+
 # announcement on every page
 ANNOUNCEMENT_TEXT = dict_get(config, None, 'announcement')
 

--- a/src/registration/templates/registration/index.html
+++ b/src/registration/templates/registration/index.html
@@ -103,4 +103,9 @@
             {% endfor %}
         </div>
     {% endif %}
+    {% if enable_show_more_events %}
+        <div class="mt-3">
+            <a href="{% url 'index_all_events' %}">{% trans "Display all Events" %}</a>
+        </div>
+    {% endif %}
 {% endblock %}

--- a/src/registration/urls.py
+++ b/src/registration/urls.py
@@ -7,6 +7,8 @@ from .feeds import HelperFeed
 urlpatterns = [
     url(r'^$', views.index, name='index'),
 
+    url(r'^all/$', views.index_all_events, name='index_all_events'),
+
     # about
     url(r'^about/$',
         TemplateView.as_view(template_name='registration/about.html'),

--- a/src/registration/views/__init__.py
+++ b/src/registration/views/__init__.py
@@ -1,5 +1,5 @@
-from .registration import index, form, registered, validate, deregister, \
-    deleted, update_personal
+from .registration import index_all_events, index, form, registered, validate, \
+    deregister, deleted, update_personal
 
 from .admin import admin, manage_event, jobs_and_shifts, coordinators
 from .event import edit_event, edit_event_admins, delete_event, archive_event, duplicate_event


### PR DESCRIPTION
This value is configurable in helfertool.yaml and is defaulted to 3
Years.
There still is a button at the very bottom to not filter old events and
display all of them

closes #37
Getting things done for 1.1!