### PR TITLE
OIDC: Allow usage of id_token for claim validation

### DIFF
--- a/src/helfertool.yaml
+++ b/src/helfertool.yaml
@@ -142,6 +142,9 @@ authentication:
     #        # Endpoint URLs
     #        authorization_endpoint: "http://localhost:8080/auth/realms/test/protocol/openid-connect/auth"
     #        token_endpoint: "http://localhost:8080/auth/realms/test/protocol/openid-connect/token"
+    #
+    #        # Optional: If present, the endpoint is must return all relevant info for authentication and authorization.
+    #        #           If omitted, information is expected to be contained in the id_token
     #        user_endpoint: "http://localhost:8080/auth/realms/test/protocol/openid-connect/userinfo"
     #
     #        # URI to get JWKS

--- a/src/helfertool/oidc.py
+++ b/src/helfertool/oidc.py
@@ -61,9 +61,16 @@ class CustomOIDCAuthenticationBackend(OIDCAuthenticationBackend):
         # check if admin privilege should be assigned based on claims
         if settings.OIDC_CUSTOM_CLAIM_ADMIN:
             user.is_superuser = user.is_staff = self._check_claim_for_flag(claims, settings.OIDC_CUSTOM_CLAIM_ADMIN)
-        
+
         user.save()
         return user
+
+    def get_userinfo(self, access_token, id_token, payload):
+        if settings.OIDC_OP_USER_ENDPOINT:
+            return super(CustomOIDCAuthenticationBackend, self).get_userinfo(access_token, id_token, payload)
+        else:
+            # Assume payload of id_token contains all information
+            return payload
 
     def _check_claim_for_flag(self, claims, conf):
         # get config and check if it is there


### PR DESCRIPTION
Currently the userinfo endpoint is required to return all information
about the user, including authorization info like roles. There are
setups where the oidc id_token already contains this information while
the userinfo endpoint serves less claims. Allow sysadmins to use either
the id_token or the userinfo by not setting the userinfo endpoint