### PR TITLE
Add option to make sessioncookie SameSite policy Lax to allow cross-origin OIDC

### DIFF
--- a/src/helfertool.yaml
+++ b/src/helfertool.yaml
@@ -154,6 +154,10 @@ authentication:
     #        client_id: "helfertool"
     #        client_secret: "<SECRET>"
     #
+    #        # Controls the session cookie SameSite - policy, forcing it to "Lax", which allows 302 redirects from a foreign domain.
+    #        # Set this to True, if your oidc provider resides on a different top level domain name than the helfertool. (defaults to False)
+    #        # is_foreign_tld: False
+    #
     #    # Permissions based on claims
     #    claims:
     #        # There are two types to handle claims

--- a/src/helfertool/settings.py
+++ b/src/helfertool/settings.py
@@ -331,7 +331,11 @@ if not DEBUG:
 
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_SECURE = True
-    SESSION_COOKIE_SAMESITE = "Strict"
+    # OIDC with foreign TLDs is blocked by SAMESITE=Strict, so make this configurable
+    if oidc_config and dict_get(oidc_config, False, 'provider', 'is_foreign_tld'):
+        SESSION_COOKIE_SAMESITE = "Lax"
+    else:
+        SESSION_COOKIE_SAMESITE = "Strict"
 
     LANGUAGE_COOKIE_HTTPONLY = True
     LANGUAGE_COOKIE_SECURE = True


### PR DESCRIPTION
I had the problem with a helfertool running at `helfer.ABC.de` and my OIDC provider running at `login.XYZ.de` where I could not login and was denied access.

Comparing the requests showed: the 302-Redirect to /oidc/callback did not get the session cookie from my browser, therefore the OIDC-Nonce was not known to the helfertool, locking me out.

This fix allows to change the session cookie policy to "Lax" (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) , so it is sent upon the 302 from my OIDC provider.

Not the finest solution, but OIDC is some kind of "Cross Site Request" that is made by your browser on behalf of the ODIC provider to transfer authentication information into your session.