### PR TITLE
Disable shifts in the past

### DIFF
--- a/src/registration/forms/registration.py
+++ b/src/registration/forms/registration.py
@@ -9,6 +9,7 @@ from .widgets import ShiftTableRegistrationWidget
 from ..models import Helper, Shift
 
 import itertools
+import datetime
 
 
 class RegisterForm(forms.ModelForm):
@@ -152,6 +153,9 @@ class RegisterForm(forms.ModelForm):
             # check if shift is blocked
             if shift.blocked and self.respect_blocked:
                 raise ValidationError(_("You selected a blocked shift."))
+
+            if shift.begin < datetime.datetime.now().astimezone():
+                raise ValidationError(_("You selected shift in the past."))
 
         # infection instruction needed but field not set?
         if infection_instruction_needed and not self.cleaned_data.get("infection_instruction"):

--- a/src/registration/locale/de/LC_MESSAGES/django.po
+++ b/src/registration/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: helfertool\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-25 19:30+0200\n"
+"POT-Creation-Date: 2023-04-16 09:08+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -71,7 +71,7 @@ msgstr "Kommentar"
 
 #: registration/export/excel.py:131 registration/export/pdf.py:88
 #: registration/templates/registration/admin/coordinators.html:5
-#: registration/templates/registration/admin/helpers_for_job.html:82
+#: registration/templates/registration/admin/helpers_for_job.html:80
 msgid "Coordinators"
 msgstr "Koordinator:innen"
 
@@ -84,7 +84,7 @@ msgid "Name"
 msgstr "Name"
 
 #: registration/export/pdf.py:104
-#: registration/templates/registration/admin/helpers_for_job.html:141
+#: registration/templates/registration/admin/helpers_for_job.html:139
 msgid "Nobody is registered for this shift."
 msgstr "Es ist niemand zu dieser Schicht angemeldet."
 
@@ -161,33 +161,33 @@ msgstr ""
 msgid "Date to copy from"
 msgstr "Datum, von dem kopiert werden soll"
 
-#: registration/forms/registration.py:74
+#: registration/forms/registration.py:75
 #: registration/templates/registration/admin/delete_helper.html:31
 #: registration/templates/registration/admin/edit_event_admins.html:10
 #: registration/templates/registration/admin/edit_job_admins.html:10
-#: registration/templates/registration/admin/helpers.html:80
+#: registration/templates/registration/admin/helpers.html:78
 msgid "Show"
 msgstr "Anzeigen"
 
-#: registration/forms/registration.py:81
+#: registration/forms/registration.py:82
 msgid "I confirm to be full aged."
 msgstr "Ich bestätige volljährig zu sein."
 
-#: registration/forms/registration.py:88
+#: registration/forms/registration.py:89
 msgid "I want to be informed about future events that are looking for helpers."
 msgstr ""
 "Ich möchte über weitere Veranstaltungen, die nach Helfer:innen suchen, "
 "informiert werden."
 
-#: registration/forms/registration.py:89
+#: registration/forms/registration.py:90
 msgid "Show privacy statement"
 msgstr "Datenschutzerklärung anzeigen"
 
-#: registration/forms/registration.py:120
+#: registration/forms/registration.py:121
 msgid "The registration is not possible as the event is archived."
 msgstr "Die Anmeldung ist nicht möglich, da die Veranstaltung archiviert ist."
 
-#: registration/forms/registration.py:126
+#: registration/forms/registration.py:127
 msgid ""
 "The public registration for this event is disabled. Use the form in the "
 "admin interface."
@@ -195,27 +195,34 @@ msgstr ""
 "Die öffentliche Anmeldung für diese Veranstaltung ist deaktiviert. Verwende "
 "das Formular im Admin Interface."
 
-#: registration/forms/registration.py:131
+#: registration/forms/registration.py:132
 msgid "You must select at least one shift."
 msgstr "Du musst mindestens eine Schicht auswählen."
 
-#: registration/forms/registration.py:135
+#: registration/forms/registration.py:136
 msgid "We are not allowed to accept helpers that are not of full age."
 msgstr "Wir dürfen keine Helfer:innen akzeptieren, die nicht volljährig sind."
 
-#: registration/forms/registration.py:139
+#: registration/forms/registration.py:140
 msgid "Please accept the data privacy statement."
 msgstr "Bitte akzeptiere die Datenschutzerklärung."
 
-#: registration/forms/registration.py:150
+#: registration/forms/registration.py:151
 msgid "You selected a full shift."
 msgstr "Du hast eine volle Schicht ausgewählt."
 
-#: registration/forms/registration.py:154
+#: registration/forms/registration.py:155
 msgid "You selected a blocked shift."
 msgstr "Du hast eine gesperrte Schicht ausgewählt."
 
-#: registration/forms/registration.py:160
+
+#: registration/forms/registration.py:158
+#, fuzzy
+#| msgid "You selected a full shift."
+msgid "You selected shift in the past."
+msgstr "Du hast eine Schicht in der Vergangenheit ausgewählt."
+
+#: registration/forms/registration.py:164
 msgid ""
 "Please tell us, if you received already an instruction for the handling of "
 "food."
@@ -223,7 +230,7 @@ msgstr ""
 "Bitte gib an, ob du bereits eine Belehrung im Umgang mit Lebensmitteln "
 "erhalten hast."
 
-#: registration/forms/registration.py:168
+#: registration/forms/registration.py:172
 #, python-format
 msgid "Some of your shifts overlap more then %(minutes)d minutes."
 msgstr ""
@@ -355,8 +362,8 @@ msgid "Name for URL"
 msgstr "Name für URL"
 
 #: registration/models/event.py:124
-msgid "May contain the following chars: a-zA-Z0-9."
-msgstr "Darf die folgenden Zeichen enthalten: a-zA-Z0-9."
+msgid "May contain letters, numbers, underscores or hyphens."
+msgstr "Darf Buchstaben, Zahlen, Unterstriche und Bindestriche enthalten"
 
 #: registration/models/event.py:128
 msgid "Date"
@@ -499,7 +506,7 @@ msgstr "Die Veranstaltung ist archiviert"
 msgid "Available T-shirt sizes"
 msgstr "Verfügbare T-Shirt Größen"
 
-#: registration/models/event.py:292
+#: registration/models/event.py:294
 msgid "The following sizes are used and therefore cannot be removed: {}"
 msgstr ""
 "Die folgenden Größen werden verwendet und können daher nicht entfernt "
@@ -701,8 +708,8 @@ msgid "More information about the Helfertool can be found here:"
 msgstr "Mehr Informationen über das Helfertool gibt es hier:"
 
 #: registration/templates/registration/admin/add_helper.html:5
-#: registration/templates/registration/admin/helpers_for_job.html:122
-#: registration/templates/registration/admin/helpers_for_job.html:127
+#: registration/templates/registration/admin/helpers_for_job.html:120
+#: registration/templates/registration/admin/helpers_for_job.html:125
 msgid "Add helper"
 msgstr "Helfer:in hinzufügen"
 
@@ -745,8 +752,8 @@ msgstr ""
 "innen hinzuzufügen."
 
 #: registration/templates/registration/admin/archive_event.html:5
-#: registration/templates/registration/admin/edit_event.html:206
-#: registration/templates/registration/admin/edit_event.html:216
+#: registration/templates/registration/admin/edit_event.html:208
+#: registration/templates/registration/admin/edit_event.html:218
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
@@ -759,7 +766,7 @@ msgstr ""
 "und Koordinator:innen gelöscht!"
 
 #: registration/templates/registration/admin/archive_event.html:10
-#: registration/templates/registration/admin/edit_event.html:210
+#: registration/templates/registration/admin/edit_event.html:212
 msgid ""
 "The number of registered helpers per shift and the number of coordinators "
 "are saved. All personal data will be deleted irrevocably."
@@ -779,7 +786,7 @@ msgid "This page is not available since the event is archived."
 msgstr "Diese Seite ist nicht verfügbar da die Veranstaltung archiviert ist."
 
 #: registration/templates/registration/admin/coordinators.html:11
-#: registration/templates/registration/admin/helpers_for_job.html:94
+#: registration/templates/registration/admin/helpers_for_job.html:92
 msgid "There are no coordinators for this job."
 msgstr "Es gibt keine Koordinator:innen für diese Schicht."
 
@@ -815,8 +822,8 @@ msgid "Delete"
 msgstr "Löschen"
 
 #: registration/templates/registration/admin/delete_event.html:5
-#: registration/templates/registration/admin/edit_event.html:223
-#: registration/templates/registration/admin/edit_event.html:228
+#: registration/templates/registration/admin/edit_event.html:225
+#: registration/templates/registration/admin/edit_event.html:230
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
@@ -883,8 +890,8 @@ msgid "There are registered helpers for this shift!"
 msgstr "Es sind Helfer:innen für diese Schicht angemeldet!"
 
 #: registration/templates/registration/admin/duplicate_event.html:5
-#: registration/templates/registration/admin/edit_event.html:181
-#: registration/templates/registration/admin/edit_event.html:188
+#: registration/templates/registration/admin/edit_event.html:183
+#: registration/templates/registration/admin/edit_event.html:190
 msgid "Duplicate event"
 msgstr "Veranstaltung duplizieren"
 
@@ -984,15 +991,15 @@ msgstr "Nach Anmeldung"
 msgid "Logos"
 msgstr "Logos"
 
-#: registration/templates/registration/admin/edit_event.html:133
+#: registration/templates/registration/admin/edit_event.html:135
 msgid "Requested helper data"
 msgstr "Abgefragte Daten der Helfer:innen"
 
-#: registration/templates/registration/admin/edit_event.html:154
+#: registration/templates/registration/admin/edit_event.html:156
 msgid "Features"
 msgstr "Features"
 
-#: registration/templates/registration/admin/edit_event.html:176
+#: registration/templates/registration/admin/edit_event.html:178
 #: registration/templates/registration/admin/edit_helper.html:38
 #: registration/templates/registration/admin/edit_job.html:56
 #: registration/templates/registration/admin/edit_link.html:20
@@ -1004,32 +1011,32 @@ msgstr "Features"
 msgid "Save"
 msgstr "Speichern"
 
-#: registration/templates/registration/admin/edit_event.html:183
+#: registration/templates/registration/admin/edit_event.html:185
 msgid "You can duplicate this event."
 msgstr "Du kannst diese Veranstaltung duplizieren."
 
-#: registration/templates/registration/admin/edit_event.html:185
+#: registration/templates/registration/admin/edit_event.html:187
 msgid "All settings are copied to the new event, but personal data is not."
 msgstr ""
 "Alle Einstellungen werden in die neue Veranstaltung kopiert, "
 "personenbezogene Daten nicht."
 
-#: registration/templates/registration/admin/edit_event.html:195
-#: registration/templates/registration/admin/edit_event.html:202
+#: registration/templates/registration/admin/edit_event.html:197
+#: registration/templates/registration/admin/edit_event.html:204
 #: registration/templates/registration/admin/move_event.html:5
 msgid "Move event"
 msgstr "Veranstaltung veschieben"
 
-#: registration/templates/registration/admin/edit_event.html:197
+#: registration/templates/registration/admin/edit_event.html:199
 msgid "You can move this event."
 msgstr "Du kannst diese Veranstaltung verschieben."
 
-#: registration/templates/registration/admin/edit_event.html:199
+#: registration/templates/registration/admin/edit_event.html:201
 msgid "The event with all shifts is moved to a new date."
 msgstr ""
 "Die Veranstaltung wird mit allen Schichten auf ein neues Datum verschoben."
 
-#: registration/templates/registration/admin/edit_event.html:208
+#: registration/templates/registration/admin/edit_event.html:210
 msgid ""
 "You can archive this event, this means that all coordinators and helpers are "
 "deleted."
@@ -1037,7 +1044,7 @@ msgstr ""
 "Du kannst diese Veranstaltung archivieren, das bedeutet, dass alle "
 "Koordinator:innen und Helfer:innen gelöscht werden."
 
-#: registration/templates/registration/admin/edit_event.html:225
+#: registration/templates/registration/admin/edit_event.html:227
 msgid "You can delete this event including all jobs, shifts and helpers."
 msgstr ""
 "Du kannst diese Veranstaltung mit allen Aufgaben, Schichten und Helfer:innen "
@@ -1227,17 +1234,17 @@ msgstr "Daten exportieren"
 msgid "All days"
 msgstr "Alle Tage"
 
-#: registration/templates/registration/admin/helpers.html:57
-#: registration/templates/registration/admin/helpers_for_job.html:65
+#: registration/templates/registration/admin/helpers.html:55
+#: registration/templates/registration/admin/helpers_for_job.html:63
 msgid "Close"
 msgstr "Schließen"
 
-#: registration/templates/registration/admin/helpers.html:71
+#: registration/templates/registration/admin/helpers.html:69
 #: registration/templates/registration/admin/jobs_and_shifts.html:21
 msgid "Public"
 msgstr "Öffentlich"
 
-#: registration/templates/registration/admin/helpers.html:85
+#: registration/templates/registration/admin/helpers.html:83
 #, python-format
 msgid "Number of coordinators: %(number)s"
 msgstr "Anzahl der Koordinator:innen: %(number)s"
@@ -1252,16 +1259,16 @@ msgstr "Helfer:innen für %(jobname)s"
 msgid "Export data for %(jobname)s"
 msgstr "Daten für %(jobname)s exportieren"
 
-#: registration/templates/registration/admin/helpers_for_job.html:87
+#: registration/templates/registration/admin/helpers_for_job.html:85
 msgid "Add coordinator"
 msgstr "Koordinator:in hinzufügen"
 
-#: registration/templates/registration/admin/helpers_for_job.html:108
+#: registration/templates/registration/admin/helpers_for_job.html:106
 #, python-format
 msgid "%(current)s of %(total)s"
 msgstr "%(current)s von %(total)s"
 
-#: registration/templates/registration/admin/helpers_for_job.html:134
+#: registration/templates/registration/admin/helpers_for_job.html:132
 msgid "Set presence for complete shift"
 msgstr "Anwesenheit für komplette Schicht setzen"
 
@@ -1886,7 +1893,7 @@ msgid "Sending the mail failed, but the registration was saved."
 msgstr ""
 "Senden der E-Mail fehlgeschlagen, die Anmeldung wurde dennoch gespeichert."
 
-#: registration/views/registration.py:262
+#: registration/views/registration.py:268
 msgid "Sending the mail failed, but the change was saved."
 msgstr ""
 "Senden der E-Mail fehlgeschlagen, die Änderung wurde dennoch gespeichert."
@@ -1894,6 +1901,9 @@ msgstr ""
 #: registration/views/shift.py:69
 msgid "Shift deleted"
 msgstr "Schicht gelöscht"
+
+#~ msgid "May contain the following chars: a-zA-Z0-9."
+#~ msgstr "Darf die folgenden Zeichen enthalten: a-zA-Z0-9."
 
 #~ msgid "Mail delivery failed"
 #~ msgstr "E-Mail Zustellung fehlgeschlagen"

--- a/src/registration/static/registration/js/form.js
+++ b/src/registration/static/registration/js/form.js
@@ -70,6 +70,20 @@ function update_shift_registration(input_field) {
     });
 }
 
+function disable_shift_in_past() {
+    // do not allow to select shifts in the past
+    $('.timeouted input.registration_possible').each(function (i, element) {
+        if(element.dataset.begin < Date.now() / 1000) {
+            // Shift started in the past
+            console.log(element)
+            element.disabled = true;
+            $(element).removeClass('registration_possible');
+        }
+    });
+}
+disable_shift_in_past();
+setInterval(disable_shift_in_past, 5 * 60 * 1000);
+
 // update and register event handler for every field
 $('input.registration_possible').each(function (i, element) {
     update_shift_registration(element);

--- a/src/registration/templates/registration/partials/registerform.html
+++ b/src/registration/templates/registration/partials/registerform.html
@@ -1,6 +1,6 @@
 {% load i18n django_bootstrap5 icons static shifts toolsettings %}
 
-<form action="" method="post" id="register_form" data-max-overlapping="{{ event.max_overlapping }}">
+<form action="" method="post" id="register_form" class="{% if not form.is_internal %}timeouted{% endif %}" data-max-overlapping="{{ event.max_overlapping }}">
     {% csrf_token %}
 
     {% form_shifttable form.shifts %}


### PR DESCRIPTION
Disable registration after start of a shift, so an event can be kept open and people can sign up until start.

eliminates the need to close registration on start of event.