### PR TITLE
additionally request oidc role scope

### DIFF
--- a/src/helfertool/settings.py
+++ b/src/helfertool/settings.py
@@ -240,7 +240,7 @@ if oidc_config:
     OIDC_OP_TOKEN_ENDPOINT = dict_get(oidc_config, None, "provider", "token_endpoint")
     OIDC_OP_USER_ENDPOINT = dict_get(oidc_config, None, "provider", "user_endpoint")
 
-    OIDC_RP_SCOPES = "openid email profile"  # also ask for profile -> given_name and family_name
+    OIDC_RP_SCOPES = "openid email profile roles"  # also ask for profile -> given_name and family_name
 
     oidc_renew_check_interval = dict_get(oidc_config, 0, "provider", "renew_check_interval")
     if oidc_renew_check_interval > 0:


### PR DESCRIPTION
Hi there,
we started using Helfertool in my archery club. Account management is handled in Nextcloud with [this OIDC identity provider plugin](https://github.com/H2CK/oidc).

Since the last update the roles are only provided if requested: https://github.com/H2CK/oidc/commit/c6b7b45f481fd758574ecc9d59eb5cd113ff246f
Which means all my admin accounts are downgraded to regular users. 

Would be great if this could be merged. I only verified the change with this one OIDC provider, so I would appreciate if you could test it in another setup.