### PR TITLE
Redirect to origin after save

### DIFF
--- a/src/gifts/views/present.py
+++ b/src/gifts/views/present.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect
+from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import never_cache
 
@@ -17,7 +18,7 @@ from .utils import notactive
 @never_cache
 @archived_not_available
 def set_present(request, event_url_name, shift_pk):
-    event, job, shift, helper = get_or_404(event_url_name, shift_pk=shift_pk)
+    event, job, shift, _helper = get_or_404(event_url_name, shift_pk=shift_pk)
 
     # check permission
     if not has_access(request.user, event, ACCESS_GIFTS_HANDLE_PRESENCE):
@@ -34,7 +35,9 @@ def set_present(request, event_url_name, shift_pk):
 
         messages.success(request, _("Presence was saved"))
 
-        return redirect("gifts:set_present", event_url_name=event.url_name, shift_pk=shift.pk)
+        return redirect(
+            f"{reverse('helpers_for_job', kwargs={'event_url_name': event.url_name, 'job_pk': shift.job.pk})}#{shift.pk}"
+        )
 
     context = {"event": event, "shift": shift, "form": form}
     return render(request, "gifts/set_present.html", context)

--- a/src/registration/templates/registration/admin/helpers_for_job.html
+++ b/src/registration/templates/registration/admin/helpers_for_job.html
@@ -101,7 +101,7 @@
 
         {# iterate over shifts on this day #}
         {% for shift in shifts %}
-            <h3 class="m-0">{{ shift.time_hours }}
+            <h3 class="m-0" id="{{ shift.pk }}">{{ shift.time_hours }}
                 <span class="badge badge-outline-secondary ms-1">
                     {% blocktrans trimmed with current=shift.num_helpers total=shift.number %}
                         {{ current }} of {{ total }}

--- a/src/registration/templates/registration/admin/jobs_and_shifts.html
+++ b/src/registration/templates/registration/admin/jobs_and_shifts.html
@@ -13,7 +13,7 @@
     {% endif %}
 
     {% for job in event.job_set.all %}
-        <h2>
+        <h2 id="{{ job.pk }}">
             {{ job.name }}
 
             {% if job.public %}

--- a/src/registration/views/job.py
+++ b/src/registration/views/job.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect, get_object_or_404
+from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import never_cache
 
@@ -62,7 +63,7 @@ def edit_job(request, event_url_name, job_pk=None):
             },
         )
 
-        return redirect("jobs_and_shifts", event_url_name=event_url_name)
+        return redirect(f"{reverse('jobs_and_shifts', kwargs={'event_url_name': event_url_name})}#{job.pk}")
 
     # render page
     context = {"event": event, "job": job, "form": form}
@@ -82,7 +83,11 @@ def edit_job_admins(request, event_url_name, job_pk=None):
     all_forms = []
     job_admin_roles = JobAdminRoles.objects.filter(job=job)
     for job_admin in job_admin_roles:
-        form = JobAdminRolesForm(request.POST or None, instance=job_admin, prefix="user_{}".format(job_admin.user.pk))
+        form = JobAdminRolesForm(
+            request.POST or None,
+            instance=job_admin,
+            prefix="user_{}".format(job_admin.user.pk),
+        )
         all_forms.append(form)
 
     # another form to add one new admin
@@ -178,7 +183,12 @@ def delete_job(request, event_url_name, job_pk):
                 break
 
     # render page
-    context = {"event": event, "job": job, "helpers_registered": helpers_registered, "form": form}
+    context = {
+        "event": event,
+        "job": job,
+        "helpers_registered": helpers_registered,
+        "form": form,
+    }
     return render(request, "registration/admin/delete_job.html", context)
 
 

--- a/src/registration/views/shift.py
+++ b/src/registration/views/shift.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect
+from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import never_cache
 
@@ -44,7 +45,7 @@ def edit_shift(request, event_url_name, job_pk, shift_pk=None):
             },
         )
 
-        return redirect("jobs_and_shifts", event_url_name=event_url_name)
+        return redirect(f"{reverse('jobs_and_shifts', kwargs={'event_url_name':event_url_name})}#{job_pk}")
 
     # render page
     context = {"event": job.event, "job": job, "shift": shift, "form": form}


### PR DESCRIPTION
When editing a shift or job, saving always leads to the top of the page. For large events with multiple shifts over multiple days, scrolling gets quite annoying. These changes lead the user back to the job they were just editing.

A simmilar logic applies to setting the presence of a shift. After saving, the user is redirected to the shift they set presence for.


- Adds ids to jobs in the jobs and shifts admin menu
- Adds ids to shifts in the helpers for job admin menu --
- Modifies redirect from modifing shift or job to link back to job in shift and jobs menu
- Modifies redirect from setting presence back to shift in helpers for job menu