### PR TITLE
Fix Healthcheck: In edge cases the manage.py can output more on stdout during initialization.

### DIFF
--- a/deployment/container/healthcheck.sh
+++ b/deployment/container/healthcheck.sh
@@ -12,7 +12,7 @@ die () {
 
 # check webserver (with a host header that is allowed)
 cd /helfertool/src
-host="$(/helfertool/venv/bin/python manage.py shell -c "from django.conf import settings ; print(settings.ALLOWED_HOSTS[0] if settings.ALLOWED_HOSTS else '')")"
+host="$(/helfertool/venv/bin/python manage.py shell -c "from django.conf import settings ; print(settings.ALLOWED_HOSTS[0] if settings.ALLOWED_HOSTS else '')" | tail -n 1)"
 curl --fail --silent --output /dev/null -H "Host: $host" http://localhost:8000 || die "Error on HTTP query"
 
 # check supervisord


### PR DESCRIPTION
I have encountered a problem where django initialization outputs some random garbage on stdout.

This leads to the healthcheck not running properly (since it has multiple lines of garbage as $host).

Which now leads to the docker container restarting randomly, since the healthcheck is not "healthy".

This is not a root-cause fix for all random garbage, but it will make the healthcheck more resilient.