### PR TITLE
Fix healthcheck script

### DIFF
--- a/deployment/container/healthcheck.sh
+++ b/deployment/container/healthcheck.sh
@@ -12,7 +12,7 @@ die () {
 
 # check webserver (with a host header that is allowed)
 cd /helfertool/src
-host="$(/helfertool/venv/bin/python manage.py shell -c "from django.conf import settings ; print(settings.ALLOWED_HOSTS[0] if settings.ALLOWED_HOSTS else '')")"
+host="$(/helfertool/venv/bin/python manage.py shell -v 0 -c "from django.conf import settings ; print(settings.ALLOWED_HOSTS[0] if settings.ALLOWED_HOSTS else '')")"
 curl --fail --silent --output /dev/null -H "Host: $host" http://localhost:8000 || die "Error on HTTP query"
 
 # check supervisord


### PR DESCRIPTION
In newer django versions the output included
`52 objects imported automatically (use -v 2 for details). ` before the
actual first host
